### PR TITLE
FIX ensure only the latest status per service is returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ logs/
 # OS specific
 .DS_Store
 Thumbs.db
+.aider*
+incidents.db
+.python-version
+

--- a/cline_docs/activeContext.md
+++ b/cline_docs/activeContext.md
@@ -1,17 +1,61 @@
-# Active Context
+# activeContext.md
 
-## Current Task
-- Creating a new FastAPI project with a health endpoint
-- Setting up basic project structure
-- Implementing health check endpoint
+## Plan to Fix Failing Test
 
-## Recent Changes
-- Initial project setup
-- Created Memory Bank documentation
+### Issue
 
-## Next Steps
-1. Create FastAPI project structure
-2. Set up virtual environment
-3. Install required dependencies
-4. Implement health endpoint
-5. Add tests
+The test `test_get_recent_incidents_latest_per_service` is failing because the `/incidents/recent` endpoint returns all incidents for a service instead of only the latest incident per service.
+
+The assertion `assert len(service_a_incidents) == 1` fails because `service_a_incidents` has a length of 3 instead of 1.
+
+### Analysis
+
+- The `/incidents/recent` endpoint currently retrieves recent incidents without grouping by service or filtering to the most recent incident per service.
+- To fix the test, we need to modify the endpoint to return only the latest incident for each service.
+
+### Solution
+
+1. **Modify Imports in `src/app/main.py`**:
+
+   Add the necessary SQLAlchemy functions to support grouping and aggregation.
+
+   ```python
+   from sqlalchemy import select, desc, func, and_
+   ```
+
+2. **Update the Query in `/incidents/recent` Endpoint**:
+
+   Adjust the query to select the latest incident per service using a subquery.
+
+   ```python
+   subquery = (
+       select(
+           Incident.service,
+           func.max(Incident.created_at).label('max_created_at')
+       ).group_by(Incident.service).subquery()
+   )
+
+   query = (
+       select(Incident)
+       .join(
+           subquery,
+           and_(
+               Incident.service == subquery.c.service,
+               Incident.created_at == subquery.c.max_created_at
+           )
+       )
+   )
+
+   result = await db.execute(query)
+   incidents = result.scalars().all()
+   ```
+
+3. **Test the Changes**:
+
+   Run `test_get_recent_incidents_latest_per_service` to confirm that it now passes.
+
+### Next Steps
+
+- Verify that other tests are still passing to ensure no regressions.
+- Review the updated endpoint for performance considerations.
+- Update any relevant documentation to reflect the changes.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version control settings to exclude unnecessary files.
- **Bug Fixes**
  - Enhanced the incident retrieval endpoint to return only the most recent incident per service when no specific count is provided.
- **Tests**
  - Added new validations to ensure incidents are correctly ordered with distinct timestamps.
- **Documentation**
  - Revised internal guides to reflect improvements in the incident handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Ensure that the `/incidents/recent` endpoint returns only the most recent incident per service by updating the query logic to incorporate grouping and filtering.

### Why are these changes being made?

The endpoint previously returned all incidents for each service, causing a test to fail due to multiple entries per service. This change solves the problem by modifying the query to ensure that only the latest incident for each service is retrieved, which aligns with the specification and fixes the test `test_get_recent_incidents_latest_per_service`. The added test cases and query adjustments ensure functionality and maintain performance considerations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->